### PR TITLE
#000014 modified internal error in a script.

### DIFF
--- a/static/multi_switch/js/logs.js
+++ b/static/multi_switch/js/logs.js
@@ -199,7 +199,7 @@ let TimerLogs = {
         });
 
         // 1枠(40px=1時間)内に最大いくつアイコンが重なるかを算出
-        let basementTime = new Date(targetLogs[0].switch_time);
+        let basementTime = new Date(targetLogs.length > 0 ? targetLogs[0].switch_time: null);
         let max_icons_in_a_row = 1;
         let icons_in_a_row = 1;
 


### PR DESCRIPTION
[現象]
指定日付内のデータが０件の場合にJS内部でエラーが発生する。

[原因]
グラフアイコンの幅調整ロジック #4 の中で、いかなる状況でも対象ログ１件目を参照する部分があったため。

[対応]
対象ログが0件の場合には回避する分岐を追加した。

