### PR TITLE
#000011 modified updating logs with API in iOS Safari

### DIFF
--- a/static/multi_switch/js/logs.js
+++ b/static/multi_switch/js/logs.js
@@ -114,7 +114,7 @@ let TimerLogs = {
             // "noCalendar": false, // カレンダーを非表示
             "enableSeconds": true, // '秒' を有効
             "time_24hr": true, // 24時間表示
-            "dateFormat": "Y-m-d H:i", // 時間のフォーマット "時:分:秒"
+            "dateFormat": "Y/m/d H:i", // 時間のフォーマット "時:分:秒"
             // "maxDate": new Date(),
             // "defaultDate": new Date(), // タイムピッカーのデフォルトタイム
         });
@@ -381,13 +381,13 @@ let TimerLogs = {
             // "noCalendar": false, // カレンダーを非表示
             "enableSeconds": true, // '秒' を有効
             "time_24hr": true, // 24時間表示
-            "dateFormat": "Y-m-d H:i", // 時間のフォーマット "時:分:秒"
+            "dateFormat": "Y/m/d H:i", // 時間のフォーマット "時:分:秒"
             "maxDate": new Date(),
             "defaultDate": new Date(), // タイムピッカーのデフォルトタイム
         });
 
         // 年月日時分
-        datetime_instance.setDate(targetLogDatetimeObject, null, "Y-m-d H:i");
+        datetime_instance.setDate(targetLogDatetimeObject, null, "Y/m/d H:i");
         if($('.flatpickr-mobile').val()){
             $('.flatpickr-mobile').val($('.flatpickr-mobile').val().slice(0, -3));
         }


### PR DESCRIPTION
[現象]
iPhone(Safari)でログ更新ができない

[原因]
iPhone(Safari)だとnew Date()するときに年月日がyyyy-mm-ddだとInvalidになる。yyyy/mm/ddだとうまくいく。

[対応]
というわけでそういうふうになおす

