### PR TITLE
#000022 modified a wrong Japanese designation

### DIFF
--- a/static/multi_switch/js/tools.js
+++ b/static/multi_switch/js/tools.js
@@ -163,13 +163,13 @@ datetimeTools = {
      */
     convertJapaneseDesignation: function(date){
         let now = new Date();
-        let delta = datetimeTools.getDelta(now, date);
+        let delta = now.getDate() - date.getDate();
         let result = '';
-        if(delta.deltaDate < 1){
+        if(delta < 1){
             result = '今日';
-        } else if(delta.deltaDate < 2) {
+        } else if(delta < 2) {
             result = '昨日'
-        } else if(delta.deltaDate < 3){
+        } else if(delta < 3){
             result = 'おととい'
         }
         return result;


### PR DESCRIPTION
[現象]
前回時間が昨日なのに「今日」と表示されることがある

[原因]
時分秒込の差分で算出してたから24時間未満の差分は今日扱い
（現在）6/25 12:00
（前回）6/24 18:00
→差分は0日と18時間と0分0秒で1日以下なので
「今日」を表示というアホみたいなロジックになってた

[対応]
日付だけで差分算出するように変更
