### PR TITLE
#000023 modified text-wrap in the log list

### DIFF
--- a/static/multi_switch/css/logs.css
+++ b/static/multi_switch/css/logs.css
@@ -666,19 +666,8 @@
 .log-list .list-row .info .note{
     color: #666666;
     font-size: 12px;
-}
-.log-list .list-row .info .note pre{
-    display: block;
-    margin: inherit;
-    font-size: initial;
-    line-height: inherit;
-    word-break: initial;
-    word-wrap: initial;
-    background-color: initial;
-    border: 0;
-    border-radius: 0px;
-    font-family: inherit;
-    padding: 0;
+    white-space: pre-wrap;
+    word-wrap: break-word;
 }
 
 .log-list .list-row .edit{

--- a/static/multi_switch/js/logs.js
+++ b/static/multi_switch/js/logs.js
@@ -531,7 +531,7 @@ let Logs = {
 
         let $info_note_div = $('<div></div>');
         $info_note_div.addClass('note')
-            .append($('<pre>' + (note ? note : "---") + '</pre>'))
+            .append(note ? note : "---")
             .appendTo($info_div);
 
         // Editアイコン


### PR DESCRIPTION
[現象]
ログ画面リスト形式表示中にメモの文字列の長さによってレイアウト崩れが起きる

[原因]
pre要素あたりが融通がきかないのかな

[対応]
pre要素を削除してCSSに以下追記
white-space: pre-wrap;
word-wrap: break-word;

