### PR TITLE
#000024 modified the icon color of night off in log list screen

### DIFF
--- a/static/multi_switch/css/logs.css
+++ b/static/multi_switch/css/logs.css
@@ -627,7 +627,7 @@
 
 .log-list .list-row .list-icon.night-off i{
     content: url(/static/multi_switch/img/night_off_64.png);
-    background-color: #bcaaa4;
+    background-color: #ffcdd2;
 }
 
 .log-list .list-row .list-icon.edit i{


### PR DESCRIPTION
[現象]
ログ画面リスト形式の「よるね(終了)」アイコンの色が他画面と違う

[原因]
#16 の修正漏れ

[対応]
他画面と同じ背景色を設定