### PR TITLE
#000025 modified the icon caption of helmet off

### DIFF
--- a/static/multi_switch/js/tools.js
+++ b/static/multi_switch/js/tools.js
@@ -284,7 +284,7 @@ switchTypeTools = {
                 break;
             case CONST.TYPE_ID.HELMET:
                 if(is_on === true){
-                    name = CONST.TYPE_NAME.HELMET_OFF;
+                    name = CONST.TYPE_NAME.HELMET_ON;
                 } else if (is_on === false){
                     name = CONST.TYPE_NAME.HELMET_OFF;
                 } else {


### PR DESCRIPTION
[現象]
ログ画面リスト形式の画面でへるめっと(装着)ログのアイコンキャプションが「へるめっと(休憩)」になっている

[原因]
キャプション名変換ロジック内の分岐でON/OFFの記述が間違っていた

[対応]
正しく動作するように修正