### PR TITLE
#000046 modified user icon style

### DIFF
--- a/static/multi_switch/css/inquiries.css
+++ b/static/multi_switch/css/inquiries.css
@@ -258,7 +258,6 @@ html{
 }
 .detail-row .profile{
     border-radius: 50%;
-    overflow: hidden;
     width: 40px;
     height: 40px;
 }
@@ -271,6 +270,7 @@ html{
 .detail-row .balloon{
     margin-left: 16px;
     position: relative;
+    width: 100%;
 }
 
 .detail-row .balloon .balloon-tip{


### PR DESCRIPTION
[現象]
といあわせ詳細 - ユーザーアイコンにかぶってる

[原因]
CSSのoverflow:hiddenあたり

[対応]
削除