### PR TITLE
#000054 modified loading error in the log screen

### DIFF
--- a/static/multi_switch/css/inquiries.css
+++ b/static/multi_switch/css/inquiries.css
@@ -256,6 +256,20 @@ html{
     display: flex;
     flex-direction: row-reverse;
 }
+
+.detail-row.date{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: #ffffff;
+}
+
+.detail-row.date .date-sign{
+    background-color: #4488DD;
+    padding: 2px 10px;
+    border-radius: 16px;
+}
+
 .detail-row .profile{
     border-radius: 50%;
     width: 40px;

--- a/static/multi_switch/js/inquiries.js
+++ b/static/multi_switch/js/inquiries.js
@@ -348,7 +348,14 @@ let inquiries = {
         let $detailRowBody = $('.detail-row-body');
         let previousNumber = $('.detail-row').length;
         $detailRowBody.empty();
+
+        let tempDateObj = new Date();
         inquiries.details.forEach(function(det){
+            let detDateObj = new Date(det.created_time);
+            if(datetimeTools.compareDate(tempDateObj, detDateObj)){
+                inquiries.createDateSignElement(detDateObj);
+                tempDateObj = new Date(detDateObj.getTime());
+            }
             inquiries.createBalloonElement(det);
         });
         if(inquiries.details.length !== previousNumber){
@@ -406,6 +413,14 @@ let inquiries = {
         let $popOption = elementTools.createBase('div', ['option'], $pop);
         let $popOptionTime = elementTools.createBase('div', ['time'], $popOption);
         $popOptionTime.text(datetimeTools.convertToStringFormat(new Date(detail.created_time)).slice(11, -3));
+    },
+
+    /**
+     * 日付表示要素作成
+     * @param dateObj
+     */
+    createDateSignElement: function(dateObj){
+
     },
 
     /**

--- a/static/multi_switch/js/logs.js
+++ b/static/multi_switch/js/logs.js
@@ -357,7 +357,7 @@ let Logs = {
      */
     calculateIconPosition: function(targetLogs){
         // 各列の高さ占有値
-        let laneLimits = [0];
+        let laneLimits = [-20];
         for(let i = 0; i < targetLogs.length; i++){
             // 起点
             let baseLog = targetLogs[i];


### PR DESCRIPTION
[現象]
きろく画面でローディング中のままになる

[原因]
0時00分～0時29分59秒にログが記録されると、グラフに表示するアイコンの高さ計算時に高さが負値で算出される。それがその日の最初のログだと、列決定ロジック内にて対象ログが最初のログにもかかわらず２列目に配置されることになる。そのままロジックを回すとOutOfRange。

[対応]
最初ログに対するの列決定の閾値は0ではなく-20とすることで列を１列目のままに維持できロジックも回る。とりあえずの処置といったところ。