### PR TITLE
#000042 modified japanese designation logi

### DIFF
--- a/static/multi_switch/js/tools.js
+++ b/static/multi_switch/js/tools.js
@@ -163,7 +163,8 @@ datetimeTools = {
      */
     convertJapaneseDesignation: function(date){
         let now = new Date();
-        let delta = now.getDate() - date.getDate();
+        let diff = now.getTime() - date.getTime();
+        let delta = Math.floor(diff / (1000 * 60 * 60 * 24));
         let result = '';
         if(delta < 1){
             result = '今日';


### PR DESCRIPTION
[現象]
月初だと昨日の記録なのに「きょう」ってなる

[原因]
差分のとり方が月マタギまで考慮されていなかった

[対応]
考慮した実装に変更