### PR TITLE
#000059 add a dialog when cancel new add in the log screen

### DIFF
--- a/static/multi_switch/css/base.css
+++ b/static/multi_switch/css/base.css
@@ -121,7 +121,7 @@ html{
 .container{
     width: 100%;
     max-width: 480px;
-    min-width: 360px;
+    min-width: 320px;
     border: 1px #f0f0f0 solid;
     border-radius: 16px;
     margin-top: 48px;

--- a/static/multi_switch/js/inquiries.js
+++ b/static/multi_switch/js/inquiries.js
@@ -57,12 +57,14 @@ let inquiries = {
 
         /* メッセージ入力エリアにフォーカスがあたったときのリサイズ */
         $container.on('focusin', '#adding-form-detail-contents', function(){
+            inquiries.toggleMessageArea();
             setTimeout(inquiries.setConversationsAreaHeight, 150);
         });
         $container.on('input', '#adding-form-detail-contents', function(){
             setTimeout(inquiries.setConversationsAreaHeight, 150);
         });
         $container.on('focusout', '#adding-form-detail-contents', function(){
+            inquiries.toggleMessageArea();
             setTimeout(inquiries.setConversationsAreaHeight, 150);
         });
         // コメント欄右送信ボタン
@@ -117,7 +119,7 @@ let inquiries = {
                 after();
             },
             "error": function (e) {
-                alert('Error:問い合わせ取得APIエラー\r' + e.responseText);
+                libraryTools.popSimpleToast('Error:問い合わせ取得APIエラー\r' + e.responseText);
             }
         });
     },
@@ -440,11 +442,12 @@ let inquiries = {
     setConversationsAreaHeight: function(){
         let height = $(window).height()
         - parseInt($('.global-bar').css('height').slice(0, -2))
-        - parseInt($('.basic-info').css('height').slice(0, -2))
+        - ($('.basic-info').attr('display') !== 'true' ? 0 : parseInt($('.basic-info').css('height').slice(0, -2)))
         - parseInt($('.message-area').css('height').slice(0, -2));
         let $detailRowBody = $('.detail-row-body');
         $detailRowBody.css('height', height + 'px');
         $detailRowBody.scrollTop(Number.MAX_SAFE_INTEGER);
+        $('#screen-name').text(parseInt($('.detail-row-body').css('height'))); //test
     },
 
     /**
@@ -594,6 +597,22 @@ let inquiries = {
         M.textareaAutoResize($('#adding-form-contents'));
     },
 
+    /**
+     * メッセージエリアにフォーカスがあたってるときにいろいろ隠すやつ
+     */
+    toggleMessageArea: function(){
+        let $globalBar = $('.global-bar');
+        let $basicInfo = $('.basic-info');
+        if($basicInfo.attr('display') === 'true'){
+            // $globalBar.attr('display', 'false').hide();
+            $basicInfo.attr('display', 'false').hide();
+        } else {
+            // $globalBar.attr('display', 'true').show();
+            $basicInfo.attr('display', 'true').show();
+
+        }
+
+    },
 
 };
 

--- a/static/multi_switch/js/logs.js
+++ b/static/multi_switch/js/logs.js
@@ -102,17 +102,28 @@ let Logs = {
 
         /* ログ詳細 キャンセルボタン */
         $('.btn-cancel').on('click', function(){
-           $('.log-detail').hide();
+            Logs.openCancelConfirmDialog();
         });
 
         /* 背景にも キャンセルボタン と同じ効果*/
         $('.log-detail').on('click', function(){
-           $('.log-detail').hide();
+            Logs.openCancelConfirmDialog();
         });
 
         /* 本体くりっくを　背景にでんぱさせない(バブリング解除) */
         $('.log-detail .detail-body').on('click', function(e){
             e.stopPropagation();
+        });
+
+        /* キャンセル OK */
+        $('.btn-cancel-ok').on('click', function(e){
+            Logs.closeCancelConfirmDialog();
+            $('.log-detail').hide();
+        });
+
+        /* キャンセル キャンセル */
+        $('.btn-cancel-cancel').on('click', function(e){
+            Logs.closeCancelConfirmDialog();
         });
 
         /* アイコン → ログ詳細 */
@@ -774,18 +785,44 @@ let Logs = {
     },
 
     /**
-     * 確認ダイアログ表示
+     * 削除確認ダイアログ表示
      */
     openDeletionConfirmDialog: function(){
+        $('.confirmation .dialog .contents.delete').show();
+        $('.confirmation .dialog .footer btn-delete-ok').show();
+        $('.confirmation .dialog .footer btn-delete-cancel').show();
         $('.confirmation').show();
     },
 
     /**
-     * 確認ダイアログ非表示
+     * 削除確認ダイアログ非表示
      */
     closeDeletionConfirmDialog: function(){
         $('.confirmation').hide();
+        $('.confirmation .dialog .contents').hide();
+        $('.confirmation .dialog .contents .footer .btn').hide();
+
     },
+
+    /**
+     * キャンセル確認ダイアログ表示
+     */
+    openCancelConfirmDialog: function(){
+        $('.confirmation .dialog .contents.cancel').show();
+        $('.confirmation .dialog .footer .btn-cancel-ok').show();
+        $('.confirmation .dialog .footer .btn-cancel-cancel').show();
+        $('.confirmation').show();
+    },
+
+    /**
+     * きゃんせる確認ダイアログ非表示
+     */
+    closeCancelConfirmDialog: function(){
+        $('.confirmation').hide();
+        $('.confirmation .dialog .contents').hide();
+        $('.confirmation .dialog .contents .footer .btn').hide();
+    },
+
 
     /**
      * 表示形式切り替え

--- a/templates/multi_switch/base.html
+++ b/templates/multi_switch/base.html
@@ -20,7 +20,7 @@
 <input id="user-id" type=hidden value="{{ user_id }}">
 <input id="user-name" type=hidden value="{{ user_name }}">
 <div class="body">
-    <div class="global-bar">
+    <div class="global-bar" display="true">
         <div id="screen-name">&nbsp;</div>
         <div class="menu-open-icon"><i class="small material-icons">apps</i></div>
     </div>

--- a/templates/multi_switch/inquiries.html
+++ b/templates/multi_switch/inquiries.html
@@ -22,7 +22,7 @@
 
     <!-- The Inquiry Detail -->
     <div class="inquiries-detail" data-val="0">
-        <div class="basic-info">
+        <div class="basic-info" display="true">
             <div class="info-column  back-to-list">
                 <div class="info-row">
                     <div class="info-item">

--- a/templates/multi_switch/logs.html
+++ b/templates/multi_switch/logs.html
@@ -195,10 +195,13 @@
         <!-- 確認ダイアログ -->
         <div class="confirmation">
             <div class="dialog">
-                <div class="contents">元には戻せんぞ。<br>...良いのだな？</div>
+                <div class="contents delete" style="display: none">削除した記録は元には戻せません。<br>よろしいですか？</div>
+                <div class="contents cancel" style="display: none">入力した情報は消えます。<br>よろしいですか？</div>
                 <div class="footer">
-                    <div class="btn-delete-ok waves-effect waves-light btn red darken-2">消え去れ！</div>
-                    <div class="btn-delete-cancel waves-effect waves-light btn grey darken-1">やめます...</div>
+                    <div class="btn-delete-ok waves-effect waves-light btn red darken-2" style="display: none">消え去れ！</div>
+                    <div class="btn-delete-cancel waves-effect waves-light btn grey darken-1" style="display: none">やめます...</div>
+                    <div class="btn-cancel-ok waves-effect waves-light btn blue darken-2" style="display: none">構わぬ！</div>
+                    <div class="btn-cancel-cancel waves-effect waves-light btn grey darken-1" style="display: none">困るよ...</div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
[現象]
きろくがめんでキャンセルボタンを押すorダイアログ外を押すとダイアログが消えて入力した情報がパーになる

[原因]
なし

[対応]
キャンセルイベントに対して確認ダイアログを挟むようにした